### PR TITLE
Fix in IoT ESP8266 mqtt received handler example

### DIFF
--- a/iot/Samples/esp8266/Esp8266YandexIoTCoreSample.ino
+++ b/iot/Samples/esp8266/Esp8266YandexIoTCoreSample.ino
@@ -97,9 +97,8 @@ void messageReceived(char* topic, byte* payload, unsigned int length) {
   DEBUG_SERIAL.println(topicString.c_str());
   String payloadStr = "";
   for (int i=0;i<length;i++) {
-    payloadStr += (char*)payload;
+    payloadStr += (char)payload[i];
   }
-  DEBUG_SERIAL.println(payloadStr);
   DEBUG_SERIAL.print("Payload: ");
   DEBUG_SERIAL.println(payloadStr);
 }


### PR DESCRIPTION
It is just a cosmetic fix of the ESP8266 example

The Fixed bug: when incoming message is received then wrong string is shown in the serial monitor.

**before**
![image](https://user-images.githubusercontent.com/574757/103464608-26446c80-4d46-11eb-93a5-baeff1c6c15d.png)

**after fix**
![image](https://user-images.githubusercontent.com/574757/103464664-92bf6b80-4d46-11eb-862d-a151a5437947.png)

