### PR TITLE
fix terraform-ydb-state: clarify ydb table type

### DIFF
--- a/terraform-ydb-state/README.md
+++ b/terraform-ydb-state/README.md
@@ -6,7 +6,7 @@ Object Storage and Yandex Database Serverless services.
 ## Setup
 
 1. Create Yandex Database in Serverless mode and write down `Document API Endpoint` (long URL).
-2. Create Document table with `LockID` primary key (`string` type) as described in Terraform docs.
+2. Create Document table (not YDB) with `LockID` primary key (`string` type) as described in Terraform docs.
 3. Create Object Storage bucket with limited access.
 4. Create Service Account and grant it `ydb.admin` and `storage.editor` roles.
 5. Issue Static Credentials for this Service Account and write down Access Key and Secret Key.


### PR DESCRIPTION
By default Yandex Cloud UI creates YDB table which is not compatible with Terraform. Trying to use it for locks produces confusing error: "Unsupported API version".