### PR TITLE
Remove redundant xargs call.

### DIFF
--- a/serverless/functions/YDB-connect-from-serverless-function/deploy/deploy.sh
+++ b/serverless/functions/YDB-connect-from-serverless-function/deploy/deploy.sh
@@ -2,7 +2,7 @@
 #source ../.env
 #cd s3-compress-after-presign
 pwd
-export $(grep -v '^#' ./.env | xargs -d '\n')
+export $(grep -v '^#' ./.env)
 rm -R dist
 
 echo "npx tsc --build tsconfig.json"

--- a/serverless/functions/YDB-connect-from-serverless-function/deploy/first-setup-func.sh
+++ b/serverless/functions/YDB-connect-from-serverless-function/deploy/first-setup-func.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 pwd
-export $(grep -v '^#' main.env | xargs -d '\n')
+export $(grep -v '^#' main.env)
 
 echo "Удалить $FUNCTION_NAME"
 yc serverless function delete --name=$FUNCTION_NAME


### PR DESCRIPTION
-d xargs flag is part of GNU implementation and
it is missing on Mac OS. However, it seems redundant
even on Linux.

Also add +x for .sh.