### PR TITLE
Terraform files for guides

### DIFF
--- a/tutorials/terraform/clickhouse-cluster-and-vm-for-rabbitmq.tf
+++ b/tutorials/terraform/clickhouse-cluster-and-vm-for-rabbitmq.tf
@@ -3,13 +3,12 @@
 # RU: https://cloud.yandex.ru/docs/managed-clickhouse/tutorials/fetch-data-from-rabbitmq
 # EN: https://cloud.yandex.com/en/docs/managed-clickhouse/tutorials/fetch-data-from-rabbitmq
 #
-# Set the configuration of Managed Service for ClickHouse cluster and Virtual Machine
+# Set the configuration of the Managed Service for ClickHouse cluster and Virtual Machine
 
 
-# Network
 resource "yandex_vpc_network" "clickhouse-and-vm-network" {
   name        = "clickhouse-and-vm-network"
-  description = "Network for Managed Service for ClickHouse cluster and VM."
+  description = "Network for the Managed Service for ClickHouse cluster and VM."
 }
 
 # Subnet in ru-central1-a availability zone
@@ -20,30 +19,27 @@ resource "yandex_vpc_subnet" "subnet-a" {
   v4_cidr_blocks = ["10.1.0.0/16"]
 }
 
-# Security group for Managed Service for ClickHouse cluster and VM
+# Security group for the Managed Service for ClickHouse cluster and VM
 resource "yandex_vpc_default_security_group" "clickhouse-and-vm-security-group" {
   network_id = yandex_vpc_network.clickhouse-and-vm-network.id
 
-  # Allow connections to cluster from the Internet
   ingress {
     protocol       = "TCP"
-    description    = "Allow connections from the Internet"
+    description    = "Allow incoming connections to cluster from any network"
     port           = 9440
     v4_cidr_blocks = ["0.0.0.0/0"]
   }
 
-  # Allow connections to RabbitMQ
   ingress {
     protocol       = "TCP"
-    description    = "Allow connections to RabbitMQ"
+    description    = "Allow incoming connections to RabbitMQ from any network"
     port           = 5672
     v4_cidr_blocks = ["0.0.0.0/0"]
   }
 
-  # Allow SSH connections to VM
   ingress {
     protocol       = "TCP"
-    description    = "Allow SSH connections to VM from the Internet"
+    description    = "Allow incoming SSH connections to VM from the Internet"
     port           = 22
     v4_cidr_blocks = ["0.0.0.0/0"]
   }
@@ -84,8 +80,8 @@ resource "yandex_mdb_clickhouse_cluster" "clickhouse-cluster" {
   }
 
   user {
-    name     = "" # Set username for ClickHouse cluster
-    password = "" # Set user password for ClickHouse cluster
+    name     = "" # Set the username
+    password = "" # Set the user password
     permission {
       database_name = "db1"
     }
@@ -105,7 +101,7 @@ resource "yandex_compute_instance" "vm-1" {
 
   boot_disk {
     initialize_params {
-      image_id = "" # Set image ID
+      image_id = "" # Set a public image ID from https://cloud.yandex.com/en/docs/compute/operations/images-with-pre-installed-software/get-list
     }
   }
 

--- a/tutorials/terraform/clickhouse-hybrid-storage.tf
+++ b/tutorials/terraform/clickhouse-hybrid-storage.tf
@@ -1,15 +1,14 @@
-# Infrastructure for Yandex Cloud Managed Service for ClickHouse cluster with hybrid storage
+# Infrastructure for the Yandex Cloud Managed Service for ClickHouse cluster with hybrid storage
 #
 # RU: https://cloud.yandex.ru/docs/managed-clickhouse/tutorials/hybrid-storage
 # EN: https://cloud.yandex.com/en/docs/managed-clickhouse/tutorials/hybrid-storage
 #
-# Set the user name and password for Managed Service for ClickHouse cluster
+# Set the user name and password for the Managed Service for ClickHouse cluster
 
 
-# Network
 resource "yandex_vpc_network" "clickhouse_hybrid_storage_network" {
   name        = "clickhouse-hybrid-storage-network"
-  description = "Network for Managed Service for ClickHouse cluster with hybrid storage."
+  description = "Network for the Managed Service for ClickHouse cluster with hybrid storage."
 }
 
 # Subnet in ru-central1-a availability zone
@@ -20,19 +19,17 @@ resource "yandex_vpc_subnet" "subnet-a" {
   v4_cidr_blocks = ["10.1.0.0/16"]
 }
 
-# Security group for Managed Service for ClickHouse cluster
+# Security group for the Managed Service for ClickHouse cluster
 resource "yandex_vpc_default_security_group" "clickhouse-security-group" {
   network_id = yandex_vpc_network.clickhouse_hybrid_storage_network.id
 
-  # Allow connections to cluster from Internet
   ingress {
     protocol       = "TCP"
-    description    = "Allow connections from Internet"
+    description    = "Allow incoming connections to cluster from Internet"
     port           = 9440
     v4_cidr_blocks = ["0.0.0.0/0"]
   }
 
-  # Allow connections from cluster to Yandex Object Storage
   egress {
     protocol       = "ANY"
     description    = "Allow outgoing connections to any required resource"

--- a/tutorials/terraform/clickhouse-sharding/advanced-sharding-with-groups.tf
+++ b/tutorials/terraform/clickhouse-sharding/advanced-sharding-with-groups.tf
@@ -6,10 +6,9 @@
 # Set the user name and password for Managed Service for ClickHouse cluster
 
 
-# Network
 resource "yandex_vpc_network" "clickhouse_sharding_network" {
   name        = "clickhouse_sharding_network"
-  description = "Network for Managed Service for ClickHouse cluster with sharding."
+  description = "Network for the Managed Service for ClickHouse cluster with sharding."
 }
 
 # Subnet in ru-central1-a availability zone
@@ -36,11 +35,10 @@ resource "yandex_vpc_subnet" "subnet-c" {
   v4_cidr_blocks = ["10.3.0.0/24"]
 }
 
-# Security group for Managed Service for ClickHouse cluster
+# Security group for the Managed Service for ClickHouse cluster
 resource "yandex_vpc_default_security_group" "clickhouse-security-group" {
   network_id = yandex_vpc_network.clickhouse_sharding_network.id
 
-  # Allow connections to cluster from the Internet
   ingress {
     protocol       = "TCP"
     description    = "Allow incoming SSL-connections with clickhouse-client from Internet"
@@ -48,7 +46,6 @@ resource "yandex_vpc_default_security_group" "clickhouse-security-group" {
     v4_cidr_blocks = ["0.0.0.0/0"]
   }
 
-  # Allow connections from cluster to any required resource
   egress {
     protocol       = "ANY"
     description    = "Allow outgoing connections to any required resource"

--- a/tutorials/terraform/clickhouse-sharding/sharding-with-group.tf
+++ b/tutorials/terraform/clickhouse-sharding/sharding-with-group.tf
@@ -6,10 +6,9 @@
 # Set the user name and password for Managed Service for ClickHouse cluster
 
 
-# Network
 resource "yandex_vpc_network" "clickhouse_sharding_network" {
   name        = "clickhouse_sharding_network"
-  description = "Network for Managed Service for ClickHouse cluster with sharding."
+  description = "Network for the Managed Service for ClickHouse cluster with sharding."
 }
 
 # Subnet in ru-central1-a availability zone
@@ -36,7 +35,7 @@ resource "yandex_vpc_subnet" "subnet-c" {
   v4_cidr_blocks = ["10.3.0.0/24"]
 }
 
-# Security group for Managed Service for ClickHouse cluster
+# Security group for the Managed Service for ClickHouse cluster
 resource "yandex_vpc_default_security_group" "clickhouse-security-group" {
   network_id = yandex_vpc_network.clickhouse_sharding_network.id
 

--- a/tutorials/terraform/clickhouse-sharding/simple-sharding.tf
+++ b/tutorials/terraform/clickhouse-sharding/simple-sharding.tf
@@ -6,10 +6,9 @@
 # Set the user name and password for Managed Service for ClickHouse cluster
 
 
-# Network
 resource "yandex_vpc_network" "clickhouse_sharding_network" {
   name        = "clickhouse_sharding_network"
-  description = "Network for Managed Service for ClickHouse cluster with sharding."
+  description = "Network for the Managed Service for ClickHouse cluster with sharding."
 }
 
 # Subnet in ru-central1-a availability zone
@@ -36,11 +35,10 @@ resource "yandex_vpc_subnet" "subnet-c" {
   v4_cidr_blocks = ["10.3.0.0/24"]
 }
 
-# Security group for Managed Service for ClickHouse cluster
+# Security group for the Managed Service for ClickHouse cluster
 resource "yandex_vpc_default_security_group" "clickhouse-security-group" {
   network_id = yandex_vpc_network.clickhouse_sharding_network.id
 
-  # Allow connections to cluster from the Internet
   ingress {
     protocol       = "TCP"
     description    = "Allow incoming SSL-connections with clickhouse-client from Internet"
@@ -48,7 +46,6 @@ resource "yandex_vpc_default_security_group" "clickhouse-security-group" {
     v4_cidr_blocks = ["0.0.0.0/0"]
   }
 
-  # Allow connections from cluster to any required resource
   egress {
     protocol       = "ANY"
     description    = "Allow outgoing connections to any required resource"

--- a/tutorials/terraform/data-from-kafka-to-clickhouse/data-from-kafka-to-clickhouse.tf
+++ b/tutorials/terraform/data-from-kafka-to-clickhouse/data-from-kafka-to-clickhouse.tf
@@ -1,15 +1,14 @@
-# Infrastructure for Yandex Cloud Managed Service for Kafka and ClickHouse clusters
+# Infrastructure for the Yandex Cloud Managed Service for Apache Kafka® and ClickHouse clusters
 #
 # RU: https://cloud.yandex.ru/docs/managed-clickhouse/tutorials/fetch-data-from-mkf
 # EN: https://cloud.yandex.com/en/docs/managed-clickhouse/tutorials/fetch-data-from-mkf
 #
-# Set the configuration of Managed Service for Kafka and ClickHouse clusters
+# Set the configuration of the Managed Service for Apache Kafka® and ClickHouse clusters
 
 
-# Network
 resource "yandex_vpc_network" "network" {
   name        = "network"
-  description = "Network for Managed Service for Kafka and ClickHouse clusters."
+  description = "Network for the Managed Service for Apache Kafka® and ClickHouse clusters."
 }
 
 # Subnet in ru-central1-a availability zone
@@ -20,22 +19,20 @@ resource "yandex_vpc_subnet" "subnet-a" {
   v4_cidr_blocks = ["10.1.0.0/16"]
 }
 
-# Security group for Managed Service for Kafka and ClickHouse clusters
+# Security group for the Managed Service for Apache Kafka® and ClickHouse clusters
 resource "yandex_vpc_default_security_group" "security-group" {
   network_id = yandex_vpc_network.network.id
 
-  # Allow connections to Kafka cluster from the Internet
   ingress {
     protocol       = "TCP"
-    description    = "Allow connections to Kafka cluster from the Internet"
+    description    = "Allow connections to the Managed Service for Apache Kafka® cluster from the Internet"
     port           = 9091
     v4_cidr_blocks = ["0.0.0.0/0"]
   }
 
-  # Allow connections to ClickHouse cluster from the Internet
   ingress {
     protocol       = "TCP"
-    description    = "# Allow connections to ClickHouse cluster from the Internet"
+    description    = "# Allow connections to the Managed Service for ClickHouse cluster from the Internet"
     port           = 9440
     v4_cidr_blocks = ["0.0.0.0/0"]
   }
@@ -49,7 +46,7 @@ resource "yandex_vpc_default_security_group" "security-group" {
   }
 }
 
-# Managed Service for Kafka cluster
+# Managed Service for Apache Kafka® cluster
 resource "yandex_mdb_kafka_cluster" "kafka-cluster" {
   name               = "kafka-cluster"
   environment        = "PRODUCTION"
@@ -72,7 +69,7 @@ resource "yandex_mdb_kafka_cluster" "kafka-cluster" {
 
   user {
     name     = "" # Set name of the producer
-    password = "" # Set password of the producer
+    password = "" # Set the password of the producer
     permission {
       topic_name = "" # Topic name from line 94
       role       = "ACCESS_ROLE_PRODUCER"
@@ -81,7 +78,7 @@ resource "yandex_mdb_kafka_cluster" "kafka-cluster" {
 
   user {
     name     = "" # Set name of the consumer
-    password = "" # Set password of the consumer
+    password = "" # Set the password of the consumer
     permission {
       topic_name = "" # Topic name from line 94
       role       = "ACCESS_ROLE_CONSUMER"
@@ -123,8 +120,8 @@ resource "yandex_mdb_clickhouse_cluster" "clickhouse-cluster" {
   }
 
   user {
-    name     = "" # Set username for ClickHouse cluster
-    password = "" # Set user password for ClickHouse cluster
+    name     = "" # Set username
+    password = "" # Set user password
     permission {
       database_name = "db1"
     }

--- a/tutorials/terraform/kafka-connect.tf
+++ b/tutorials/terraform/kafka-connect.tf
@@ -3,17 +3,16 @@
 # RU: https://cloud.yandex.ru/docs/managed-kafka/tutorials/kafka-connect
 # EN: https://cloud.yandex.com/en/docs/managed-kafka/tutorials/kafka-connect
 #
-# Set setting:
+# Specify the following settings:
 # * Virtual Machine
 #     * Image ID: https://cloud.yandex.com/en/docs/compute/operations/images-with-pre-installed-software/get-list
 #     * OpenSSH public key
 # * Managed Service for Apache Kafka® cluster:
 #     * password for `user` account
 
-# Network
 resource "yandex_vpc_network" "kafka-connect-network" {
   name        = "kafka-connect-network"
-  description = "Network for Managed Service for Apache Kafka® cluster"
+  description = "Network for the Managed Service for Apache Kafka® cluster."
 }
 
 # Subnet in ru-central1-a availability zone
@@ -38,9 +37,7 @@ resource "yandex_compute_instance" "vm-ubuntu-20-04" {
 
   boot_disk {
     initialize_params {
-      # How to list available images list:
-      # https://cloud.yandex.com/en/docs/compute/operations/images-with-pre-installed-software/get-list
-      image_id = ""
+      image_id = "" # Set a public image ID from https://cloud.yandex.com/en/docs/compute/operations/images-with-pre-installed-software/get-list
     }
   }
 
@@ -57,20 +54,20 @@ resource "yandex_compute_instance" "vm-ubuntu-20-04" {
   }
 }
 
-# Security group for Managed Service for Apache Kafka® cluster
+# Security group for the Managed Service for Apache Kafka® cluster
 resource "yandex_vpc_default_security_group" "kafka-connect-security-group" {
   network_id = yandex_vpc_network.kafka-connect-network.id
 
   ingress {
     protocol       = "TCP"
-    description    = "Allow connections to Managed Service for Apache Kafka® broker hosts from the Internet"
+    description    = "Allow connections to the Managed Service for Apache Kafka® broker hosts from the Internet"
     port           = 9091
     v4_cidr_blocks = ["0.0.0.0/0"]
   }
 
   ingress {
     protocol       = "TCP"
-    description    = "Allow connections to Managed Service for Apache Kafka® schema registry from the Internet"
+    description    = "Allow connections to the Managed Service for Apache Kafka® schema registry from the Internet"
     port           = 9440
     v4_cidr_blocks = ["0.0.0.0/0"]
   }
@@ -117,7 +114,7 @@ resource "yandex_mdb_kafka_cluster" "kafka-connect-cluster" {
 
   user {
     name     = "user"
-    password = "" # Set password
+    password = "" # Set the password
     permission {
       topic_name = "messages"
       role       = "ACCESS_ROLE_CONSUMER"

--- a/tutorials/terraform/kafka-mirror-maker.tf
+++ b/tutorials/terraform/kafka-mirror-maker.tf
@@ -1,10 +1,10 @@
-# Infrastructure for Yandex Cloud Managed Service for Kafka and Virtual Machine
+# Infrastructure for Yandex Cloud Managed Service for Apache Kafka® cluster and Virtual Machine
 #
 # RU: https://cloud.yandex.ru/docs/managed-kafka/tutorials/mirrormaker-unmanaged-topics
 # EN: https://cloud.yandex.com/en/docs/managed-kafka/tutorials/mirrormaker-unmanaged-topics
 #
-# Set the configuration:
-# * Managed Service for Apache Kafka cluster:
+# Set the following settings:
+# * Managed Service for Apache Kafka® cluster:
 #      * admin account name
 #      * admin account password
 # * Virtual Machine:
@@ -12,10 +12,9 @@
 #      * Path to public part of SSH key
 
 
-# Network
 resource "yandex_vpc_network" "network" {
   name        = "network"
-  description = "Network for Managed Service for Kafka and VM."
+  description = "Network for the Managed Service for Apache Kafka® cluster and VM."
 }
 
 # Subnet in ru-central1-a availability zone
@@ -26,14 +25,13 @@ resource "yandex_vpc_subnet" "subnet-a" {
   v4_cidr_blocks = ["10.1.0.0/16"]
 }
 
-# Security group for Managed Service for Kafka and VM
+# Security group for the Managed Service for Apache Kafka® cluster and VM
 resource "yandex_vpc_default_security_group" "security-group" {
   network_id = yandex_vpc_network.network.id
 
-  # Allow connections to Kafka cluster from the Internet
   ingress {
     protocol       = "TCP"
-    description    = "Allow connections to Kafka cluster from the Internet"
+    description    = "Allow connections to the Managed Service for Apache Kafka® cluster from the Internet"
     from_port      = 9091
     to_port        = 9092
     v4_cidr_blocks = ["0.0.0.0/0"]
@@ -81,8 +79,8 @@ resource "yandex_mdb_kafka_cluster" "kafka-cluster" {
   }
 
   user {
-    name     = "" # Set admin username for Kafka cluster
-    password = "" # Set admin password for Kafka cluster
+    name     = "" # Set admin username
+    password = "" # Set admin password
     permission {
       topic_name = "*"
       role       = "ACCESS_ROLE_ADMIN"
@@ -103,7 +101,7 @@ resource "yandex_compute_instance" "vm-mirror-maker" {
 
   boot_disk {
     initialize_params {
-      image_id = "" # Set image ID
+      image_id = "" # Set a public image ID from https://cloud.yandex.com/en/docs/compute/operations/images-with-pre-installed-software/get-list
     }
   }
 

--- a/tutorials/terraform/postgresql-1c.tf
+++ b/tutorials/terraform/postgresql-1c.tf
@@ -3,13 +3,12 @@
 # RU: https://cloud.yandex.ru/docs/managed-postgresql/tutorials/1c-postgresql
 # EN: https://cloud.yandex.com/en/docs/managed-postgresql/tutorials/1c-postgresql
 #
-# Set the user password for Managed Service for PostgreSQL 1C cluster on line 59
+# Set the user password for Managed Service for PostgreSQL 1C cluster
 
 
-# Network
 resource "yandex_vpc_network" "postgresql-1c-network" {
   name        = "postgresql-1c-network"
-  description = "Network for Managed Service for PostgreSQL 1C cluster"
+  description = "Network for the Managed Service for PostgreSQL 1C cluster."
 }
 
 # Subnet in ru-central1-a availability zone
@@ -36,14 +35,13 @@ resource "yandex_vpc_subnet" "subnet-c" {
   v4_cidr_blocks = ["10.3.0.0/16"]
 }
 
-# Security group for Managed Service for PostgreSQL 1C cluster
+# Security group for the Managed Service for PostgreSQL 1C cluster
 resource "yandex_vpc_default_security_group" "postgresql-security-group" {
   network_id = yandex_vpc_network.postgresql-1c-network.id
 
-  # Allow connections to cluster from the Internet
   ingress {
     protocol       = "TCP"
-    description    = "Allow connections from the Internet"
+    description    = "Allow incoming connections to cluster from the Internet"
     port           = 6432
     v4_cidr_blocks = ["0.0.0.0/0"]
   }

--- a/tutorials/terraform/redis-as-php-session-storage/redis-cluster-non-sharded-and-vm-for-php.tf
+++ b/tutorials/terraform/redis-as-php-session-storage/redis-cluster-non-sharded-and-vm-for-php.tf
@@ -3,19 +3,17 @@
 # RU: https://cloud.yandex.ru/docs/managed-redis/tutorials/redis-as-php-sessions-storage
 # EN: https://cloud.yandex.com/en/docs/managed-redis/tutorials/redis-as-php-sessions-storage
 #
-# Set the:
-#
-# * Password for Yandex Managed Service for Redis cluster
+# Set the following settings:
+# * Password for the Yandex Managed Service for Redis cluster
 # * Virtual Machine
 #     * Image ID: https://cloud.yandex.com/en/docs/compute/operations/images-with-pre-installed-software/get-list
 #     * Username (for Ubuntu images used `ubuntu` name)
 #     * Path to public part of SSH key
 
 
-# Network
 resource "yandex_vpc_network" "redis-and-vm-network" {
   name        = "redis-and-vm-network"
-  description = "Network for Managed Service for Redis cluster and VM."
+  description = "Network for the Managed Service for Redis cluster and VM."
 }
 
 # Subnet in ru-central1-a availability zone
@@ -26,57 +24,34 @@ resource "yandex_vpc_subnet" "subnet-a" {
   v4_cidr_blocks = ["10.1.0.0/16"]
 }
 
-# Security group for Managed Service for Redis cluster and VM
+# Security group for the Managed Service for Redis cluster and VM
 resource "yandex_vpc_default_security_group" "redis-and-vm-security-group" {
   network_id = yandex_vpc_network.redis-and-vm-network.id
 
-  # Allow connections to cluster from the Internet
   ingress {
     protocol       = "TCP"
-    description    = "Allow HTTP connections"
-    port           = 80
-    v4_cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  egress {
-    protocol       = "TCP"
-    description    = "Allow HTTP connections"
+    description    = "Allow incoming HTTP connections from the Internet"
     port           = 80
     v4_cidr_blocks = ["0.0.0.0/0"]
   }
 
   ingress {
     protocol       = "TCP"
-    description    = "Allow HTTPS connections"
-    port           = 443
-    v4_cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  egress {
-    protocol       = "TCP"
-    description    = "Allow HTTPS connections"
+    description    = "Allow incoming HTTPS connections from the Internet"
     port           = 443
     v4_cidr_blocks = ["0.0.0.0/0"]
   }
 
   ingress {
     protocol       = "TCP"
-    description    = "Allow direct connections to cluster"
+    description    = "Allow direct connections to cluster from the Internet"
     port           = 6379
     v4_cidr_blocks = ["0.0.0.0/0"]
   }
 
-  egress {
-    protocol       = "TCP"
-    description    = "Allow direct connections to cluster"
-    port           = 6379
-    v4_cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  # Allow connections for VM
   ingress {
     protocol       = "TCP"
-    description    = "Allow connections for VM"
+    description    = "Allow incoming SSH connections to VM from the Internet"
     port           = 22
     v4_cidr_blocks = ["0.0.0.0/0"]
   }
@@ -98,8 +73,8 @@ resource "yandex_mdb_redis_cluster" "redis-cluster" {
   security_group_ids = [yandex_vpc_default_security_group.redis-and-vm-security-group.id]
 
   config {
-    password = ""    # Set password for Redis cluster
-    version  = "6.2" # Version of Redis cluster
+    password = ""    # Set the password
+    version  = "6.2" # Version of the Redis
   }
 
   resources {
@@ -127,7 +102,7 @@ resource "yandex_compute_instance" "lamp-vm" {
 
   boot_disk {
     initialize_params {
-      image_id = "" # Set image ID
+      image_id = "" # Set a public image ID from https://cloud.yandex.com/en/docs/compute/operations/images-with-pre-installed-software/get-list
     }
   }
 

--- a/tutorials/terraform/redis-as-php-session-storage/redis-cluster-sharded-and-vm-for-php.tf
+++ b/tutorials/terraform/redis-as-php-session-storage/redis-cluster-sharded-and-vm-for-php.tf
@@ -1,21 +1,20 @@
-# Infrastructure for Yandex Cloud Managed Service for Redis sharded cluster and Virtual Machine
+# Infrastructure for the Yandex Cloud Managed Service for Redis sharded cluster and Virtual Machine
 #
 # RU: https://cloud.yandex.ru/docs/managed-redis/tutorials/redis-as-php-sessions-storage
 # EN: https://cloud.yandex.com/en/docs/managed-redis/tutorials/redis-as-php-sessions-storage
 #
-# Set the:
+# Set the following settings:
 #
-# * Password for Yandex Managed Service for Redis cluster
+# * Password for the Yandex Managed Service for Redis cluster
 # * Virtual Machine
 #     * Image ID: https://cloud.yandex.com/en/docs/compute/operations/images-with-pre-installed-software/get-list
 #     * Username (for Ubuntu images used `ubuntu` name)
 #     * Path to public part of SSH key
 
 
-# Network
 resource "yandex_vpc_network" "redis-and-vm-network" {
   name        = "redis-and-vm-network"
-  description = "Network for Managed Service for Redis cluster and VM."
+  description = "Network for the Managed Service for Redis cluster and VM."
 }
 
 # Subnet in ru-central1-a availability zone
@@ -42,57 +41,34 @@ resource "yandex_vpc_subnet" "subnet-c" {
   v4_cidr_blocks = ["10.3.0.0/16"]
 }
 
-# Security group for Managed Service for Redis cluster and VM
+# Security group for the Managed Service for Redis cluster and VM
 resource "yandex_vpc_default_security_group" "redis-and-vm-security-group" {
   network_id = yandex_vpc_network.redis-and-vm-network.id
 
-  # Allow connections to cluster from the Internet
   ingress {
     protocol       = "TCP"
-    description    = "Allow HTTP connections"
-    port           = 80
-    v4_cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  egress {
-    protocol       = "TCP"
-    description    = "Allow HTTP connections"
+    description    = "Allow incoming HTTP connections from the Internet"
     port           = 80
     v4_cidr_blocks = ["0.0.0.0/0"]
   }
 
   ingress {
     protocol       = "TCP"
-    description    = "Allow HTTPS connections"
-    port           = 443
-    v4_cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  egress {
-    protocol       = "TCP"
-    description    = "Allow HTTPS connections"
+    description    = "Allow incoming HTTPS connections from the Internet"
     port           = 443
     v4_cidr_blocks = ["0.0.0.0/0"]
   }
 
   ingress {
     protocol       = "TCP"
-    description    = "Allow direct connections to cluster"
+    description    = "Allow incoming connections to cluster from the Internet"
     port           = 6379
     v4_cidr_blocks = ["0.0.0.0/0"]
   }
 
-  egress {
-    protocol       = "TCP"
-    description    = "Allow direct connections to cluster"
-    port           = 6379
-    v4_cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  # Allow connections for VM
   ingress {
     protocol       = "TCP"
-    description    = "Allow connections for VM"
+    description    = "Allow incoming SSH connections to VM from the Internet"
     port           = 22
     v4_cidr_blocks = ["0.0.0.0/0"]
   }
@@ -115,8 +91,8 @@ resource "yandex_mdb_redis_cluster" "redis-cluster" {
   sharded            = true
 
   config {
-    password = ""    # Set password for Redis cluster
-    version  = "6.2" # Version of Redis cluster
+    password = ""    # Set the password
+    version  = "6.2" # Version of the Redis
   }
 
   resources {
@@ -157,7 +133,7 @@ resource "yandex_compute_instance" "lamp-vm" {
 
   boot_disk {
     initialize_params {
-      image_id = "" # Set image ID
+      image_id = "" # Set a public image ID from https://cloud.yandex.com/en/docs/compute/operations/images-with-pre-installed-software/get-list
     }
   }
 

--- a/tutorials/terraform/redis-migration/redis-cluster-non-sharded.tf
+++ b/tutorials/terraform/redis-migration/redis-cluster-non-sharded.tf
@@ -105,8 +105,9 @@ resource "yandex_compute_instance" "intermediate-vm" {
   }
 
   network_interface {
-    subnet_id = yandex_vpc_subnet.subnet-a.id
-    nat       = true # Required for connection from the Internet
+    subnet_id          = yandex_vpc_subnet.subnet-a.id
+    nat                = true # Required for connection from the Internet
+    security_group_ids = [yandex_vpc_default_security_group.redis-and-vm-security-group.id]
   }
 
   metadata = {

--- a/tutorials/terraform/redis-migration/redis-cluster-non-sharded.tf
+++ b/tutorials/terraform/redis-migration/redis-cluster-non-sharded.tf
@@ -1,15 +1,14 @@
-# Infrastructure for Yandex Cloud Managed Service for Redis non sharded cluster and Virtual Machine
+# Infrastructure for the Yandex Cloud Managed Service for Redis non sharded cluster and Virtual Machine
 #
 # RU: https://cloud.yandex.ru/docs/managed-redis/tutorials/redis-as-php-sessions-storage
 # EN: https://cloud.yandex.com/en/docs/managed-redis/tutorials/redis-as-php-sessions-storage
 #
-# Set the configuration of Managed Service for Redis cluster and Virtual Machine
+# Set the configuration of the Managed Service for Redis cluster and Virtual Machine
 
 
-# Network
 resource "yandex_vpc_network" "redis-and-vm-network" {
   name        = "redis-and-vm-network"
-  description = "Network for Managed Service for Redis cluster and VM."
+  description = "Network for the Managed Service for Redis cluster and VM."
 }
 
 # Subnet in ru-central1-a availability zone
@@ -20,7 +19,7 @@ resource "yandex_vpc_subnet" "subnet-a" {
   v4_cidr_blocks = ["10.1.0.0/16"]
 }
 
-# Security group for Managed Service for Redis cluster and VM
+# Security group for the Managed Service for Redis cluster and VM
 resource "yandex_vpc_default_security_group" "redis-and-vm-security-group" {
   network_id = yandex_vpc_network.redis-and-vm-network.id
 
@@ -70,8 +69,8 @@ resource "yandex_mdb_redis_cluster" "redis-cluster" {
   security_group_ids = [yandex_vpc_default_security_group.redis-and-vm-security-group.id]
 
   config {
-    password = ""    # Set password for Redis cluster
-    version  = "6.2" # Version of Redis cluster
+    password = ""    # Set the password
+    version  = "6.2" # Version of the Redis
   }
 
   resources {
@@ -99,7 +98,7 @@ resource "yandex_compute_instance" "intermediate-vm" {
 
   boot_disk {
     initialize_params {
-      image_id = "" # Set public image ID from https://cloud.yandex.com/en/docs/compute/operations/images-with-pre-installed-software/get-list
+      image_id = "" # Set a public image ID from https://cloud.yandex.com/en/docs/compute/operations/images-with-pre-installed-software/get-list
     }
   }
 

--- a/tutorials/terraform/redis-migration/redis-cluster-non-sharded.tf
+++ b/tutorials/terraform/redis-migration/redis-cluster-non-sharded.tf
@@ -24,21 +24,6 @@ resource "yandex_vpc_subnet" "subnet-a" {
 resource "yandex_vpc_default_security_group" "redis-and-vm-security-group" {
   network_id = yandex_vpc_network.redis-and-vm-network.id
 
-  # Allow connections to cluster from the Internet
-  ingress {
-    protocol       = "TCP"
-    description    = "Allow HTTP connections"
-    port           = 80
-    v4_cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  ingress {
-    protocol       = "TCP"
-    description    = "Allow HTTPS connections"
-    port           = 443
-    v4_cidr_blocks = ["0.0.0.0/0"]
-  }
-
   ingress {
     protocol       = "TCP"
     description    = "Allow direct connections to cluster"

--- a/tutorials/terraform/redis-migration/redis-cluster-non-sharded.tf
+++ b/tutorials/terraform/redis-migration/redis-cluster-non-sharded.tf
@@ -26,15 +26,29 @@ resource "yandex_vpc_default_security_group" "redis-and-vm-security-group" {
 
   ingress {
     protocol       = "TCP"
-    description    = "Allow direct connections to cluster"
+    description    = "Allow direct connections to master without SSL"
     port           = 6379
     v4_cidr_blocks = ["0.0.0.0/0"]
   }
 
-  # Allow connections for VM
+  # Required for clusters created with TLS
+  # ingress {
+  #   protocol       = "TCP"
+  #   description    = "Allow direct connections to master with SSL"
+  #   port           = 6380
+  #   v4_cidr_blocks = ["0.0.0.0/0"]
+  # }
+
   ingress {
     protocol       = "TCP"
-    description    = "Allow connections for VM"
+    description    = "Allow connections to Redis Sentinel"
+    port           = 26379
+    v4_cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    protocol       = "TCP"
+    description    = "Allow SSH connections for VM"
     port           = 22
     v4_cidr_blocks = ["0.0.0.0/0"]
   }

--- a/tutorials/terraform/redis-migration/redis-cluster-sharded.tf
+++ b/tutorials/terraform/redis-migration/redis-cluster-sharded.tf
@@ -40,21 +40,6 @@ resource "yandex_vpc_subnet" "subnet-c" {
 resource "yandex_vpc_default_security_group" "redis-and-vm-security-group" {
   network_id = yandex_vpc_network.redis-and-vm-network.id
 
-  # Allow connections to cluster from the Internet
-  ingress {
-    protocol       = "TCP"
-    description    = "Allow HTTP connections"
-    port           = 80
-    v4_cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  ingress {
-    protocol       = "TCP"
-    description    = "Allow HTTPS connections"
-    port           = 443
-    v4_cidr_blocks = ["0.0.0.0/0"]
-  }
-
   ingress {
     protocol       = "TCP"
     description    = "Allow direct connections to cluster"

--- a/tutorials/terraform/redis-migration/redis-cluster-sharded.tf
+++ b/tutorials/terraform/redis-migration/redis-cluster-sharded.tf
@@ -1,15 +1,14 @@
-# Infrastructure for Yandex Cloud Managed Service for Redis sharded cluster and Virtual Machine
+# Infrastructure for the Yandex Cloud Managed Service for Redis sharded cluster and Virtual Machine
 #
 # RU: https://cloud.yandex.ru/docs/managed-redis/tutorials/redis-as-php-sessions-storage
 # EN: https://cloud.yandex.com/en/docs/managed-redis/tutorials/redis-as-php-sessions-storage
 #
-# Set the configuration of Managed Service for Redis cluster and Virtual Machine
+# Set the configuration of the Managed Service for Redis cluster and Virtual Machine
 
 
-# Network
 resource "yandex_vpc_network" "redis-and-vm-network" {
   name        = "redis-and-vm-network"
-  description = "Network for Managed Service for Redis cluster and VM."
+  description = "Network for the Managed Service for Redis cluster and VM."
 }
 
 # Subnet in ru-central1-a availability zone
@@ -36,7 +35,7 @@ resource "yandex_vpc_subnet" "subnet-c" {
   v4_cidr_blocks = ["10.3.0.0/16"]
 }
 
-# Security group for Managed Service for Redis cluster and VM
+# Security group for the Managed Service for Redis cluster and VM
 resource "yandex_vpc_default_security_group" "redis-and-vm-security-group" {
   network_id = yandex_vpc_network.redis-and-vm-network.id
 
@@ -80,8 +79,8 @@ resource "yandex_mdb_redis_cluster" "redis-cluster" {
   sharded            = true
 
   config {
-    password = ""    # Set password for Redis cluster
-    version  = "6.2" # Version of Redis cluster
+    password = ""    # Set the password
+    version  = "6.2" # Version of the Redis
   }
 
   resources {
@@ -122,7 +121,7 @@ resource "yandex_compute_instance" "intermediate-vm" {
 
   boot_disk {
     initialize_params {
-      image_id = "" # Set public image ID from https://cloud.yandex.com/en/docs/compute/operations/images-with-pre-installed-software/get-list
+      image_id = "" # Set a public image ID from https://cloud.yandex.com/en/docs/compute/operations/images-with-pre-installed-software/get-list
     }
   }
 

--- a/tutorials/terraform/redis-migration/redis-cluster-sharded.tf
+++ b/tutorials/terraform/redis-migration/redis-cluster-sharded.tf
@@ -42,15 +42,22 @@ resource "yandex_vpc_default_security_group" "redis-and-vm-security-group" {
 
   ingress {
     protocol       = "TCP"
-    description    = "Allow direct connections to cluster"
+    description    = "Allow direct connections to masters without SSL"
     port           = 6379
     v4_cidr_blocks = ["0.0.0.0/0"]
   }
 
-  # Allow connections for VM
+  # Required for clusters created with TLS support
+  # ingress {
+  #   protocol       = "TCP"
+  #   description    = "Allow direct connections to master with SSL"
+  #   port           = 6380
+  #   v4_cidr_blocks = ["0.0.0.0/0"]
+  # }
+
   ingress {
     protocol       = "TCP"
-    description    = "Allow connections for VM"
+    description    = "Allow SSH connections for VM"
     port           = 22
     v4_cidr_blocks = ["0.0.0.0/0"]
   }

--- a/tutorials/terraform/redis-migration/redis-cluster-sharded.tf
+++ b/tutorials/terraform/redis-migration/redis-cluster-sharded.tf
@@ -135,8 +135,9 @@ resource "yandex_compute_instance" "intermediate-vm" {
   }
 
   network_interface {
-    subnet_id = yandex_vpc_subnet.subnet-a.id
-    nat       = true # Required for connection from the Internet
+    subnet_id          = yandex_vpc_subnet.subnet-a.id
+    nat                = true # Required for connection from the Internet
+    security_group_ids = [yandex_vpc_default_security_group.redis-and-vm-security-group.id]
   }
 
   metadata = {


### PR DESCRIPTION
Added Terraform configuration files for article: https://cloud.yandex.ru/docs/managed-redis/tutorials/data-migration

Fixed typing errors and removed useless comments in some files.

Updated `kafka-connect.tf` file:

* removed unused security group rules
* fixed resources names
* removed image ID for VM, added link to instruction for getting this list