### PR TITLE
Refact: remove redundant comments check

### DIFF
--- a/products-prepare/linux/yc-image-cleanup.sh
+++ b/products-prepare/linux/yc-image-cleanup.sh
@@ -484,7 +484,7 @@ function getNonLockedUsers {
         PASSWD_FILE=/etc/master.passwd
     fi
 
-    for USER in $(cat /etc/passwd| grep -v -e "^#" | grep -v -e "^#" | getColumn "$SYSDB_DELIMITER" 1); do
+    for USER in $(cat /etc/passwd | grep -v -e "^#" | getColumn "$SYSDB_DELIMITER" 1); do
         USERPW=$(cat "$PASSWD_FILE" | grep -v -e "^#" | getRowByColumnValue "$SYSDB_DELIMITER" 1 "$USER" | awk -F "$SYSDB_DELIMITER" '{print($2)}')
         if [ "$USERPW" == "" ]; then
             OS_TYPE=$(getOS)


### PR DESCRIPTION
It seems there is no reason to skip comments twice.